### PR TITLE
buildsteps_feed.py: adopt buildbot to new cli

### DIFF
--- a/masters/master/buildsteps_feed.py
+++ b/masters/master/buildsteps_feed.py
@@ -34,10 +34,9 @@ feed_create_tmpdir = ShellCommand(
 def feed_make_command(props):
     command = ['nice',
 	'./build_all_targets',
-	'19.07.7',
-        Interpolate('src-git falter https://github.com/Freifunk-Spalter/packages.git;%(prop:buildername)s'),
-        Interpolate('%(prop:builddir)s/tmp'),
-        'build_parallel'
+    Interpolate('src-git falter https://github.com/Freifunk-Spalter/packages.git;%(prop:buildername)s'),
+    Interpolate('%(prop:builddir)s/tmp'),
+    'build_parallel'
         ]
     return command
 


### PR DESCRIPTION
In https://github.com/Freifunk-Spalter/repo_builder/pull/12 the
invocation of the repo_builder changed. Thus it can select the
right sdk-version by itself now.

Signed-off-by: Martin Hübner <martin.hubner@web.de>

once https://github.com/Freifunk-Spalter/repo_builder/pull/12 got merged, this needs to be merged too.